### PR TITLE
FIXED - multiple collaborator instances bug

### DIFF
--- a/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseElements/Nodes/GitHubCommit.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseElements/Nodes/GitHubCommit.java
@@ -1,6 +1,7 @@
 package com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseElements.Nodes;
 
 import com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseUtils.Collections.GitHubFileList;
+import com.example.TechnicalAnalysis.Services.GitHubService.GitHubCollaboratorBuilder;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ public class GitHubCommit implements GitHubEntity {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E MMM d HH:mm:ss yyyy Z");
         this.date = LocalDateTime.parse(commitInfo.get(4), formatter);
 
-        this.author = new GitHubCollaborator(this.author_id, commitInfo.get(1));
+        this.author = GitHubCollaboratorBuilder.getCollaborator(this.author_id, commitInfo.get(1));
 //        this.files = new GitHubFileList(commitFiles);
     }
 

--- a/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubCollaboratorList.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubCollaboratorList.java
@@ -1,5 +1,6 @@
 package com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseUtils.Collections;
 
+import com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseElements.Nodes.GitHubCollaborator;
 import com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseElements.Nodes.GitHubEntity;
 import org.json.simple.JSONArray;
 
@@ -27,6 +28,12 @@ public class GitHubCollaboratorList extends GitHubEntityCollection {
     }
 
     @Override
+    public void add(GitHubEntity object) {
+        GitHubCollaborator collaborator = (GitHubCollaborator) object;
+        this.list.put(collaborator.getId(), collaborator);
+    }
+
+    @Override
     public Iterator<GitHubEntity> iterator() {
         return list.values().iterator();
     }
@@ -40,4 +47,5 @@ public class GitHubCollaboratorList extends GitHubEntityCollection {
     public Spliterator<GitHubEntity> spliterator() {
         return list.values().spliterator();
     }
+
 }

--- a/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubCommitList.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubCommitList.java
@@ -42,6 +42,12 @@ public class GitHubCommitList extends GitHubEntityCollection {
         }
     }
 
+    @Override
+    public void add(GitHubEntity object) {
+        GitHubCommit commit = (GitHubCommit) object;
+        this.list.put(commit.getSha(), commit);
+    }
+
     public GitHubCommit get(String sha) {
         try {
             return (GitHubCommit) this.list.get(sha);

--- a/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubEntityCollection.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubEntityCollection.java
@@ -12,4 +12,6 @@ public abstract class GitHubEntityCollection implements Iterable<GitHubEntity> {
     public abstract GitHubEntity get(String key);
 
     public abstract void addAll(JSONArray array);
+
+    public abstract void add(GitHubEntity object);
 }

--- a/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubFileList.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/DatabaseService/DatabaseUtils/Collections/GitHubFileList.java
@@ -33,6 +33,12 @@ public class GitHubFileList extends GitHubEntityCollection {
     }
 
     @Override
+    public void add(GitHubEntity object) {
+        GitHubFile commit = (GitHubFile) object;
+        this.list.put(commit.getName(), commit);
+    }
+
+    @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
         list.forEach((key, value) -> stringBuilder.append(list.get(key)).append("\n"));

--- a/src/main/java/com/example/TechnicalAnalysis/Services/GitHubService/GitHubCollaboratorBuilder.java
+++ b/src/main/java/com/example/TechnicalAnalysis/Services/GitHubService/GitHubCollaboratorBuilder.java
@@ -1,0 +1,18 @@
+package com.example.TechnicalAnalysis.Services.GitHubService;
+
+import com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseElements.Nodes.GitHubCollaborator;
+import com.example.TechnicalAnalysis.Services.DatabaseService.DatabaseUtils.Collections.GitHubCollaboratorList;
+
+// Implemented factory pattern along with singleton pattern
+public abstract class GitHubCollaboratorBuilder {
+    private static final GitHubCollaboratorList collaborators = new GitHubCollaboratorList();
+
+    public static GitHubCollaborator getCollaborator(String id, String name) {
+        GitHubCollaborator collaborator = (GitHubCollaborator) collaborators.get(id);
+        if (collaborator == null) {
+            collaborator = new GitHubCollaborator(id, name);
+            collaborators.add(collaborator);
+        }
+        return collaborator;
+    }
+}


### PR DESCRIPTION
Bag: Multiple instances of the same collaborator are created at GitHubCommit object initialization.

Solution: Use of factory and singleton patterns.

Factory: GitHubCollaboratorBuilder
Singleton: getCollaborator